### PR TITLE
Update Avnet IoT Connect logic

### DIFF
--- a/avnet_rsl10_2devices/.gitignore
+++ b/avnet_rsl10_2devices/.gitignore
@@ -2,3 +2,4 @@
 /out/
 /install/
 /.vs/
+/build/

--- a/avnet_rsl10_2devices/rsl10.c
+++ b/avnet_rsl10_2devices/rsl10.c
@@ -36,10 +36,6 @@ SOFTWARE.
 // Static buffer for telemetry data
 static char telemetryBuffer[JSON_BUFFER_SIZE] = {0};
 
-#ifdef USE_IOT_CONNECT
-static char avtMsgBuffer[JSON_BUFFER_SIZE + DX_AVNET_IOT_CONNECT_METADATA] = {0};
-#endif //USE_IOT_CONNECT
-
 static DX_MESSAGE_PROPERTY *messageProperties[] = {&(DX_MESSAGE_PROPERTY){.key = "appid", .value = "Avnet RSL10 Demo"}, 
                                                    &(DX_MESSAGE_PROPERTY){.key = "type", .value = "telemetry"},
                                                    &(DX_MESSAGE_PROPERTY){.key = "schema", .value = "1"}};
@@ -503,12 +499,10 @@ void rsl10SendTelemetry(void) {
                                                                    Rsl10DeviceList[currentDevice].lastOrientation_z,
                                                                    Rsl10DeviceList[currentDevice].lastOrientation_w);
 
+                Log_Debug("Send telemetry: %s\n", telemetryBuffer);
 #ifdef USE_IOT_CONNECT
 
-                // Add the IoTConnect metadata to the seralized telemetry
-                dx_avnetJsonSerializePayload(telemetryBuffer, avtMsgBuffer, sizeof(avtMsgBuffer), NULL);
-                Log_Debug("%s\n", avtMsgBuffer);
-                dx_azurePublish(avtMsgBuffer, strlen(avtMsgBuffer), messageProperties, NELEMS(messageProperties), &contentProperties);
+                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties, NULL);
 
 #else // !USE_IOT_CONNECT
 
@@ -516,7 +510,6 @@ void rsl10SendTelemetry(void) {
                 dx_azurePublish(telemetryBuffer, strnlen(telemetryBuffer, JSON_BUFFER_SIZE),
                                     messageProperties, NELEMS(messageProperties),
                                     &contentProperties);                
-                Log_Debug("Send telemetry: %s\n", telemetryBuffer);
 #endif                 
                 // Clear the flag so we don't send this data again
                 Rsl10DeviceList[currentDevice].movementDataRefreshed = false;
@@ -541,12 +534,12 @@ void rsl10SendTelemetry(void) {
                                                                    Rsl10DeviceList[currentDevice].lastHumidity,
                                                                    Rsl10DeviceList[currentDevice].telemetryKey,
                                                                    Rsl10DeviceList[currentDevice].lastPressure);
+
+                Log_Debug("Send telemetry: %s\n", telemetryBuffer);
+
 #ifdef USE_IOT_CONNECT
 
-                // Add the IoTConnect metadata to the seralized telemetry
-                dx_avnetJsonSerializePayload(telemetryBuffer, avtMsgBuffer, sizeof(avtMsgBuffer), NULL);
-                Log_Debug("%s\n", avtMsgBuffer);
-                dx_azurePublish(avtMsgBuffer, strlen(avtMsgBuffer), messageProperties, NELEMS(messageProperties), &contentProperties);
+                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties, NULL);
 
 #else // !USE_IOT_CONNECT
 
@@ -554,7 +547,7 @@ void rsl10SendTelemetry(void) {
                 dx_azurePublish(telemetryBuffer, strnlen(telemetryBuffer, JSON_BUFFER_SIZE),
                                     messageProperties, NELEMS(messageProperties),
                                     &contentProperties);     
-                Log_Debug("Send telemetry: %s\n", telemetryBuffer);
+                
 #endif     
                 // Clear the flag so we don't send this data again
                 Rsl10DeviceList[currentDevice].movementDataRefreshed = false;
@@ -578,12 +571,12 @@ void rsl10SendTelemetry(void) {
                                                                    Rsl10DeviceList[currentDevice].lastRssi,
                                                                    Rsl10DeviceList[currentDevice].telemetryKey,
                                                                    Rsl10DeviceList[currentDevice].lastBattery);
+
+                Log_Debug("Send telemetry: %s\n", telemetryBuffer);
+
 #ifdef USE_IOT_CONNECT
 
-                // Add the IoTConnect metadata to the seralized telemetry
-                dx_avnetJsonSerializePayload(telemetryBuffer, avtMsgBuffer, sizeof(avtMsgBuffer), NULL);
-                Log_Debug("%s\n", avtMsgBuffer);
-                dx_azurePublish(avtMsgBuffer, strlen(avtMsgBuffer), messageProperties, NELEMS(messageProperties), &contentProperties);
+                dx_avnetPublish(telemetryBuffer, strlen(telemetryBuffer), messageProperties, NELEMS(messageProperties), &contentProperties, NULL);
 
 #else // !USE_IOT_CONNECT
 
@@ -591,7 +584,7 @@ void rsl10SendTelemetry(void) {
                 dx_azurePublish(telemetryBuffer, strnlen(telemetryBuffer, JSON_BUFFER_SIZE),
                                     messageProperties, NELEMS(messageProperties),
                                     &contentProperties);
-                Log_Debug("Send telemetry: %s\n", telemetryBuffer);
+                
 #endif 
                 // Clear the flag so we don't send this data again
                 Rsl10DeviceList[currentDevice].batteryDataRefreshed = false;

--- a/avnet_sk_demo/.gitignore
+++ b/avnet_sk_demo/.gitignore
@@ -2,3 +2,4 @@
 /out/
 /install/
 /.vs/
+/build/

--- a/avnet_sk_demo/app_manifest.json
+++ b/avnet_sk_demo/app_manifest.json
@@ -3,13 +3,12 @@
   "Name": "AvnetSK-V2-DevX",
   "ComponentId": "06e116bd-e3af-4bfe-a0cb-f1530b8b91ab",
   "EntryPoint": "/bin/app",
-  "CmdArgs": [ "--ScopeID", "0ne0008CB04" ],
+  "CmdArgs": [ "--ScopeID", "<Enter your Scope ID" ],
     "Capabilities": {
       "AllowedApplicationConnections": [ "b2cec904-1c60-411b-8f62-5ffe9684b8ce" ],
       "AllowedConnections": [
         "global.azure-devices-provisioning.net",
-        "poc-iotc-sphere-iothub-eu.azure-devices.net",
-        "BW-IoTHub.azure-devices.net"
+        "enter your IoTHub Hostname here"
       ],
       "Gpio": [
         "$SAMPLE_RGBLED_RED",
@@ -28,7 +27,7 @@
     "WifiConfig": true,
     "NetworkConfig": false,
     "SystemTime": false,
-    "DeviceAuthentication": "8d34f65c-532e-4dcf-a1d6-3e811c1e5c68",
+    "DeviceAuthentication": "00000000-0000-0000-0000-000000000000",
     "PowerControls": [ "ForceReboot" ]
   },
   "ApplicationType": "Default"

--- a/avnet_sk_demo/build_options.h
+++ b/avnet_sk_demo/build_options.h
@@ -22,7 +22,6 @@
 // If this is a IoT Conect build, make sure to enable the IOT Hub application code
 #ifdef USE_IOT_CONNECT
 #define IOT_HUB_APPLICATION
-#define IOT_CONNECT_API_VERSION 1
 #undef USE_PNP // Disable PNP device twins responses
 #endif 
 

--- a/avnet_sk_demo/main.h
+++ b/avnet_sk_demo/main.h
@@ -76,9 +76,6 @@ DX_USER_CONFIG dx_config;
 #ifdef IOT_HUB_APPLICATION
 static char msgBuffer[JSON_MESSAGE_BYTES] = {0};
 #endif // IOT_HUB_APPLICATION        
-#ifdef USE_IOT_CONNECT
-static char avtMsgBuffer[JSON_MESSAGE_BYTES + DX_AVNET_IOT_CONNECT_METADATA] = {0};
-#endif //USE_IOT_CONNECT
 
 #ifdef IOT_HUB_APPLICATION
 static DX_MESSAGE_PROPERTY *messageProperties[] =   {&(DX_MESSAGE_PROPERTY){.key = "appid", .value = "SK-Demo"}, 


### PR DESCRIPTION
Change examples to use new dx_avnetPublish() calls that properly format telemetry and add required message properties when using Avnet's IoTConnect cloud platform